### PR TITLE
Fix the sandbox api endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fintecture (0.3.0)
+    fintecture (0.3.1)
       faraday
 
 GEM

--- a/lib/fintecture/base_url.rb
+++ b/lib/fintecture/base_url.rb
@@ -11,7 +11,7 @@ module Fintecture
       FINTECTURE_API_URL = {
         local: 'http://localhost:3030',
         test: 'https://api-sandbox-test.fintecture.com',
-        sandbox: 'https://api-sandbox.fintecture.com',
+        sandbox: 'https://api-sandbox-test.fintecture.com',
         production: 'https://api.fintecture.com'
       }
 

--- a/lib/fintecture/base_url.rb
+++ b/lib/fintecture/base_url.rb
@@ -11,7 +11,7 @@ module Fintecture
       FINTECTURE_API_URL = {
         local: 'http://localhost:3030',
         test: 'https://api-sandbox-test.fintecture.com',
-        sandbox: 'https://api-sandbox-test.fintecture.com',
+        sandbox: 'https://api-sandbox.fintecture.com',
         production: 'https://api.fintecture.com'
       }
 

--- a/lib/fintecture/version.rb
+++ b/lib/fintecture/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fintecture
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
Fix the sandbox uri to 'https://api-sandbox-test.fintecture.com'
Upgrade version to 0.3.1

This correction was already done with the Fix-base-url-environment branch. I did not integrate it in the Evolution-to-complete-features branch