### PR TITLE
Update `generate` method signature to allow passing options from PIS Connect

### DIFF
--- a/lib/fintecture/api/pis/connect.rb
+++ b/lib/fintecture/api/pis/connect.rb
@@ -13,7 +13,7 @@ module Fintecture
     class Connect
       class << self
         # ------------ PUBLIC METHOD ------------
-        def generate(client, payload, state, redirect_uri, origin_uri, **options)
+        def generate(client, payload, state, redirect_uri, origin_uri, options)
 
           @client = client
 


### PR DESCRIPTION
With current 0.6.0 release, it triggers an error when passing `with_virtualbeneficiary: true` option to the `connect`method, returning an error like this:

```
wrong number of arguments (given 6, expected 5)
```

which is typical of method signature confusion.

Closes #26